### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Usage Example
     display = adafruit_displayio_sh1107.SH1107(display_bus, width=WIDTH, height=HEIGHT)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(WIDTH, HEIGHT, 1)

--- a/examples/displayio_sh1107_game_of_life.py
+++ b/examples/displayio_sh1107_game_of_life.py
@@ -106,10 +106,10 @@ b2 = displayio.Bitmap(display.width // SCALE, display.height // SCALE, 2)
 palette = displayio.Palette(2)
 tg1 = displayio.TileGrid(b1, pixel_shader=palette)
 tg2 = displayio.TileGrid(b2, pixel_shader=palette)
-g1 = displayio.Group(max_size=3, scale=SCALE)
+g1 = displayio.Group(scale=SCALE)
 g1.append(tg1)
 display.show(g1)
-g2 = displayio.Group(max_size=3, scale=SCALE)
+g2 = displayio.Group(scale=SCALE)
 g2.append(tg2)
 
 # First time, show the Conway tribute

--- a/examples/displayio_sh1107_random_motion.py
+++ b/examples/displayio_sh1107_random_motion.py
@@ -33,7 +33,7 @@ BORDER = 2
 display = adafruit_displayio_sh1107.SH1107(display_bus, width=WIDTH, height=HEIGHT)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(WIDTH, HEIGHT, 1)

--- a/examples/displayio_sh1107_simpletest.py
+++ b/examples/displayio_sh1107_simpletest.py
@@ -32,7 +32,7 @@ BORDER = 2
 display = adafruit_displayio_sh1107.SH1107(display_bus, width=WIDTH, height=HEIGHT)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(WIDTH, HEIGHT, 1)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a SH1107 display available to test with.