### PR TITLE
Revert the multiplex ratio to 0x7F

### DIFF
--- a/adafruit_displayio_sh1107.py
+++ b/adafruit_displayio_sh1107.py
@@ -96,7 +96,7 @@ else:
         b"\x20\x00"  # vertical (column) addressing mode (POR=0x20)
         b"\xa0\x00"  # segment remap = 1 (POR=0, down rotation)
         b"\xc0\x00"  # common output scan direction = 0 (0 to n-1 (POR=0))
-        b"\xa8\x01\x3f"  # multiplex ratio = 64 (POR=0x7F)
+        b"\xa8\x01\x7f"  # multiplex ratio = 64 (POR=0x7F)
         b"\xd3\x01\x60"  # set display offset mode = 0x60
         # b"\xd5\x01\x51"  # divide ratio/oscillator: divide by 2, fOsc (POR)
         b"\xd9\x01\x22"  # pre-charge/dis-charge period mode: 2 DCLKs/2 DCLKs (POR)

--- a/adafruit_displayio_sh1107.py
+++ b/adafruit_displayio_sh1107.py
@@ -96,7 +96,7 @@ else:
         b"\x20\x00"  # vertical (column) addressing mode (POR=0x20)
         b"\xa0\x00"  # segment remap = 1 (POR=0, down rotation)
         b"\xc0\x00"  # common output scan direction = 0 (0 to n-1 (POR=0))
-        b"\xa8\x01\x7f"  # multiplex ratio = 64 (POR=0x7F)
+        b"\xa8\x01\x7f"  # multiplex ratio = 128 (POR=0x7F)
         b"\xd3\x01\x60"  # set display offset mode = 0x60
         # b"\xd5\x01\x51"  # divide ratio/oscillator: divide by 2, fOsc (POR)
         b"\xd9\x01\x22"  # pre-charge/dis-charge period mode: 2 DCLKs/2 DCLKs (POR)

--- a/adafruit_displayio_sh1107.py
+++ b/adafruit_displayio_sh1107.py
@@ -131,7 +131,13 @@ class SH1107(displayio.Display):
         rotation=0,
         **kwargs
     ):
+        rotation = (rotation + _ROTATION_OFFSET) % 360
+        if rotation in (0, 180):
+            multiplex = kwargs["width"] - 1
+        else:
+            multiplex = kwargs["height"] - 1
         init_sequence = bytearray(_INIT_SEQUENCE)
+        init_sequence[16] = multiplex
         init_sequence[19] = display_offset
         super().__init__(
             bus,
@@ -143,7 +149,7 @@ class SH1107(displayio.Display):
             data_as_commands=True,  # every byte will have a command byte preceding
             brightness_command=0x81,
             single_byte_bounds=True,
-            rotation=(rotation + _ROTATION_OFFSET) % 360,
+            rotation=rotation,
             # for sh1107 use column and page addressing.
             #                lower column command = 0x00 - 0x0F
             #                upper column command = 0x10 - 0x17


### PR DESCRIPTION
The recent changes to page/column mode dropped the multiplex ratio from 0x7F(128) to 0x3F(64). This breaks usage with a 128x128 display (eg. [Pimoroni Mono OLED (128x128) I2C](https://shop.pimoroni.com/products/1-12-oled-breakout?variant=29421050757203)) - half the display is missing.

This reverts the multiplex ratio back to 0x7F(128)

I've tested this successfully with:
* [Adafruit FeatherWing OLED - 128x64 OLED](https://www.adafruit.com/product/4650)
* Pimoroni Mono OLED (128x128) I2C

Was the multiplex ratio dropped to 0x3F for a different display which also needs tested?