### PR TITLE
Rotation fix

### DIFF
--- a/adafruit_displayio_sh1107.py
+++ b/adafruit_displayio_sh1107.py
@@ -122,7 +122,6 @@ if sys.implementation.name == "circuitpython" and sys.implementation.version[0] 
         b"\xaf\x00"  # DISPLAY_ON
     )
     _PIXELS_IN_ROW = True
-    _ROTATION_OFFSET = 0
 else:
     _INIT_SEQUENCE = (
         b"\xae\x00"  # display off, sleep mode
@@ -142,7 +141,6 @@ else:
         b"\xaf\x00"  # DISPLAY_ON
     )
     _PIXELS_IN_ROW = False
-    _ROTATION_OFFSET = 90
 
 
 class SH1107(Display):
@@ -163,10 +161,9 @@ class SH1107(Display):
         self,
         bus: Union[I2CDisplayBus, FourWire],
         display_offset: int = DISPLAY_OFFSET_ADAFRUIT_FEATHERWING_OLED_4650,
-        rotation: int = 0,
+        rotation: int = 90,
         **kwargs
     ) -> None:
-        rotation = (rotation + _ROTATION_OFFSET) % 360
         if rotation in (0, 180):
             multiplex = kwargs["width"] - 1
         else:

--- a/examples/displayio_sh1107_simpletest.py
+++ b/examples/displayio_sh1107_simpletest.py
@@ -39,7 +39,7 @@ HEIGHT = 64
 BORDER = 2
 
 display = adafruit_displayio_sh1107.SH1107(
-    display_bus, width=WIDTH, height=HEIGHT, rotation=0
+    display_bus, width=WIDTH, height=HEIGHT
 )
 
 # Make the display context

--- a/examples/displayio_sh1107_simpletest.py
+++ b/examples/displayio_sh1107_simpletest.py
@@ -38,9 +38,7 @@ WIDTH = 128
 HEIGHT = 64
 BORDER = 2
 
-display = adafruit_displayio_sh1107.SH1107(
-    display_bus, width=WIDTH, height=HEIGHT
-)
+display = adafruit_displayio_sh1107.SH1107(display_bus, width=WIDTH, height=HEIGHT)
 
 # Make the display context
 splash = displayio.Group()


### PR DESCRIPTION
@ladyada 

Resolves: #23 

This offset being applied only during init means all subsequent rotation setting was off by 90 compared to the initial rotation. I tried overriding the property setter to apply the offset, but had no luck with that. Then it occurred to me to just remove the offset altogether and change the default rotation argument to 90. This way subsequent setting matches as expected, and the default behavior remains landscape on the OLED Featherwing. 

I tested successfully with https://www.adafruit.com/product/4650 that reproducer from the issue no longer has the unexpected rotation behavior, and that all 128x64 examples are showing the correct orientation. 