### PR TITLE
add 100ms delay to end of init sequence

### DIFF
--- a/adafruit_displayio_sh1107.py
+++ b/adafruit_displayio_sh1107.py
@@ -108,7 +108,7 @@ if sys.implementation.name == "circuitpython" and sys.implementation.version[0] 
         b"\xb0\x00"  # set page address = 0 (POR)
         b"\xa4\x00"  # entire display off, retain RAM, normal status (POR)
         b"\xa6\x00"  # normal (not reversed) display
-        b"\xaf\x00"  # DISPLAY_ON
+        b"\xaf\x80\x64"  # DISPLAY_ON + 100ms delay
     )
     _PIXELS_IN_ROW = True
 else:
@@ -127,7 +127,7 @@ else:
         # b"\xb0\x00"  # set page address = 0 (POR)
         b"\xa4\x00"  # entire display off, retain RAM, normal status (POR)
         b"\xa6\x00"  # normal (not reversed) display
-        b"\xaf\x00"  # DISPLAY_ON
+        b"\xaf\x80\x64"  # DISPLAY_ON + 100ms delay
     )
     _PIXELS_IN_ROW = False
 


### PR DESCRIPTION
I'm not 100% sure the delay mentioned in the datasheet isn't supposed to happen earlier in the power-up process but it looks like this is the right place to me and adding a .1 second delay at the end of the init sequence shouldn't cause any problems anyway. In my tests everything still works fine with this change although nothing was misbehaving without it either.

If merged this will fix #15 

Edit: One more thought, it's possible this hasn't been an issue because CP is relatively slow, however as microcontrollers get faster it might become necessary to have this delay in place.